### PR TITLE
修复右下角 `go to top` 被遮挡的问题

### DIFF
--- a/Live2d.vue
+++ b/Live2d.vue
@@ -140,7 +140,7 @@ export default {
   height: 400px;
   right: 20px;
   bottom: 20px;
-  z-index: 80;
+  z-index: 0;
 }
 
 .live2d-container canvas {


### PR DESCRIPTION
`live2d-container` 样式的 `z-index` 必须设置为小于 `1` ，否则如果 live2d 位于右下角时， `go to top` 按钮和 `刷新页面` 按钮 会由于 `z-index = 1` ，会被 live2d 遮挡，无法点击